### PR TITLE
Падение при невалидном email.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,6 @@
 LINUX32_COMPILER = gcc
 
-LIBPURPLE_CFLAGS = -I/usr/include/libpurple -DPURPLE_PLUGINS -DENABLE_NLS
-GLIB_CFLAGS = -I/usr/include/glib-2.0 -I/usr/lib/glib-2.0/include -I/usr/include
+LIBPURPLE_CFLAGS = $(shell pkg-config --cflags --libs purple) -DPURPLE_PLUGINS -DENABLE_NLS
 
 #Standard stuff here
 MRA_SOURCES =     \
@@ -48,7 +47,7 @@ clean:
 	rm -f libmra.so
 
 libmra.so:	${MRA_SOURCES}
-	${LINUX32_COMPILER} ${LIBPURPLE_CFLAGS} -Wall -Wextra -pthread ${GLIB_CFLAGS} -I. -g3 -O2 -pipe ${MRA_SOURCES} -o libmra.so -shared -fPIC -DPIC
+	${LINUX32_COMPILER} ${LIBPURPLE_CFLAGS} -Wall -Wextra -pthread -I. -g3 -O2 -pipe ${MRA_SOURCES} -o libmra.so -shared -fPIC -DPIC
 
 release:	libmra.so
 

--- a/src/libmra.c
+++ b/src/libmra.c
@@ -591,7 +591,7 @@ void mra_message_cb(gpointer data, char *from, char *message, char *message_rtf,
         conv = purple_conversation_new(PURPLE_CONV_TYPE_IM, mmp->acct, from);
     }
 
-    purple_conversation_write(conv, from, purple_markup_escape_text(message, strlen(message)), PURPLE_MESSAGE_RECV, time);
+    serv_got_im(mmp->gc, from, purple_markup_escape_text(message, strlen(message)), 0, time);
 }
 
 /**************************************************************************************************

--- a/src/libmra.c
+++ b/src/libmra.c
@@ -1227,19 +1227,19 @@ GList *mra_statuses(PurpleAccount *acct)
 	PurpleStatusType *status;
 	
 	//Online people have a status message and also a date when it was set	
-	status = purple_status_type_new_with_attrs(PURPLE_STATUS_AVAILABLE, "ONLINE", _("Online"), FALSE, TRUE, FALSE, "message", _("Message"), purple_value_new(PURPLE_TYPE_STRING), "message_date", _("Message changed"), purple_value_new(PURPLE_TYPE_STRING), NULL);
+	status = purple_status_type_new_with_attrs(PURPLE_STATUS_AVAILABLE, "available", _("Online"), FALSE, TRUE, FALSE, "message", _("Message"), purple_value_new(PURPLE_TYPE_STRING), "message_date", _("Message changed"), purple_value_new(PURPLE_TYPE_STRING), NULL);
 	types  = g_list_append(types, status);
 	
 	//Away people have a status message and also a date when it was set	
-	status = purple_status_type_new_with_attrs(PURPLE_STATUS_AWAY, "AWAY", _("Away"), FALSE, TRUE, FALSE, "message", _("Message"), purple_value_new(PURPLE_TYPE_STRING), "message_date", _("Message changed"), purple_value_new(PURPLE_TYPE_STRING), NULL);
+	status = purple_status_type_new_with_attrs(PURPLE_STATUS_AWAY, "away", _("Away"), FALSE, TRUE, FALSE, "message", _("Message"), purple_value_new(PURPLE_TYPE_STRING), "message_date", _("Message changed"), purple_value_new(PURPLE_TYPE_STRING), NULL);
 	types  = g_list_append(types, status);
 	
 	//Unavailable people have a status message and also a date when it was set	
-	status = purple_status_type_new_with_attrs(PURPLE_STATUS_UNAVAILABLE, "UNAVIALABLE", _("Unavailable"), FALSE, TRUE, FALSE, "message", _("Message"), purple_value_new(PURPLE_TYPE_STRING), "message_date", _("Message changed"), purple_value_new(PURPLE_TYPE_STRING), NULL);
+	status = purple_status_type_new_with_attrs(PURPLE_STATUS_UNAVAILABLE, "unavailable", _("Unavailable"), FALSE, TRUE, FALSE, "message", _("Message"), purple_value_new(PURPLE_TYPE_STRING), "message_date", _("Message changed"), purple_value_new(PURPLE_TYPE_STRING), NULL);
 	types  = g_list_append(types, status);
 	
 	//Offline people dont have messages
-	status = purple_status_type_new_full(PURPLE_STATUS_OFFLINE, "OFFLINE", _("Offline"), FALSE, TRUE, FALSE);
+	status = purple_status_type_new_full(PURPLE_STATUS_OFFLINE, "offline", _("Offline"), FALSE, TRUE, FALSE);
 	types  = g_list_append(types, status);
 	
 	return types;

--- a/src/mra_net.c
+++ b/src/mra_net.c
@@ -20,6 +20,7 @@
  */
 
 #include "libmra.h"
+#include <locale.h>
 
 /////////////////////////////////////XXX///////////////////////////////////////////////////////////
 #define LPS_DEBUG(c, s) (unsigned char) c[s+3], (unsigned char) c[s+2], (unsigned char) c[s+1], (unsigned char) c[s]


### PR DESCRIPTION
Фикс для как бэ закрытой баги https://github.com/dreadatour/pidgin-mra/issues/closed#issue/2

Проблема в том, что в функции mra_connect_cb поле mmp->connect_data не сбрасывется в NULL, если мыло невалидное (в libmra.c:650 выходт по return). Краш происходит в mra_close в libmra.c:1084, внутри purple_proxy_connect_cancel. К этому моменту соединение установлено (mra_connect_cb уже вызвался!!!) и дёргать purple_proxy_connect_cancel не надо.
- Перенёс прверку мыла в mra_login
- 'mmp->connect_data = NULL' перенёс в начало mra_connect_cb от греха подальше (есть ещё return'ы)
